### PR TITLE
Handle 403 Forbidden error from TikTok API

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,16 @@
 
 ##
 
+### Troubleshooting "403 Forbidden" Errors from TikTok API
+
+If you encounter a "403 Forbidden" error when using the script, it indicates that your request to TikTok was blocked. This can happen for several reasons, and here are steps you can take to resolve the issue:
+
+1. **Check Your IP Address**: Ensure your IP is not blacklisted by TikTok. Sometimes, TikTok may block IP addresses that exhibit suspicious behavior.
+2. **Use a Different IP or Proxy**: If your IP is blocked, try using a different IP address or a proxy. This can help bypass the block.
+3. **Wait and Retry**: If you suspect TikTok's rate limiting is causing the block, wait for some time before trying again. TikTok may temporarily block IPs that make too many requests in a short period.
+
+By following these steps, you can troubleshoot and potentially resolve the "403 Forbidden" error, allowing you to continue using the script without interruption.
+
 ### 📜 License & Warning
 
 - Education Propose Only !!

--- a/main.rb
+++ b/main.rb
@@ -67,7 +67,20 @@ class IDA
             'User-Agent' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/110.0.0.0 IDA'
         }
         @response = HTTParty.get("https://www.tiktok.com/@#{@username}", headers: headers)
-        @server_log = @response.body
+        if @response.code == 403
+            handle_forbidden_error
+        else
+            @server_log = @response.body
+        end
+    end
+
+    def handle_forbidden_error
+        puts "403 Forbidden Error: Your request to TikTok was blocked.".colorize(:red)
+        puts "Possible actions to resolve this issue:".colorize(:yellow)
+        puts "- Ensure your IP is not blacklisted by TikTok.".colorize(:light_blue)
+        puts "- Try using a different IP address or proxy.".colorize(:light_blue)
+        puts "- Wait and try again later if TikTok's rate limiting is causing the block.".colorize(:light_blue)
+        exit
     end
     
     def _to_json


### PR DESCRIPTION
Related to #8

Implements error handling for "403 Forbidden" responses from TikTok in the `main.rb` file and updates the `README.md` with troubleshooting steps.

- Adds a new method `handle_forbidden_error` to the `IDA` class in `main.rb` to provide users with actionable steps when encountering a "403 Forbidden" error from TikTok. This method is called within the `send_request` method if a "403 Forbidden" response is detected.
- Modifies the `send_request` method to check for a "403 Forbidden" response and calls `handle_forbidden_error` accordingly.
- Updates the `README.md` file to include a new section on troubleshooting "403 Forbidden" errors from TikTok API, offering users guidance on how to resolve such issues.
